### PR TITLE
Removed trailing comma (invalid JSON)

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -35,7 +35,7 @@
                                 "command": "open_file",
                                 "args": {"file": "${packages}/User/DjangoCommands.sublime-settings"},
                                 "caption": "Settings – User"
-                            },
+                            }
                         ]
                     }
                 ]


### PR DESCRIPTION
Because of 'Error trying to parse file: Trailing comma before closing bracket in ~/.config/sublime-text-2/Packages/Django Manage Commands/Main.sublime-menu:39:25'
