### PR TITLE
Hide the console window on Windows when calling get_version

### DIFF
--- a/django-commands.py
+++ b/django-commands.py
@@ -294,7 +294,7 @@ class DjangoSqlMigrationCommand(DjangoAppCommand):
         return os.path.splitext(tail)[0] or os.path.splitext(ntpath.basename(head))[0]
 
     def is_enabled(self):
-        return float(self.get_version()) >= 1.7 or self.get_version == 'dev'
+        return float(self.get_version()) >= 1.7 or self.get_version() == 'dev'
 
     def on_choose_migration(self, apps, index):
         if index == -1:

--- a/django-commands.py
+++ b/django-commands.py
@@ -59,7 +59,14 @@ class DjangoCommand(sublime_plugin.WindowCommand):
     def get_version(self):
         binary = self.get_executable()
         command = [binary, '-c', 'import django;print(django.get_version())']
-        output = subprocess.check_output(command)
+
+        # Hide the console window on Windows
+        startupinfo = None
+        if PLATFORM == 'Windows':
+            startupinfo = subprocess.STARTUPINFO()
+            startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+
+        output = subprocess.check_output(command, startupinfo=startupinfo)
         version = re.match(r'(\d\.\d)', output.decode('utf-8')).group(0)
         if float(version) > LATEST_DJANGO_RELEASE:
             version = 'dev'


### PR DESCRIPTION
It will show a console window on Windows when you run some commands that call get_version (i.e. DjangoOpenDocsCommand, DjangoSearchDocsCommand). This is quite annoying.