### PR TITLE
django_project_root 

### DIFF
--- a/django-commands.py
+++ b/django-commands.py
@@ -34,7 +34,7 @@ class DjangoCommand(sublime_plugin.WindowCommand):
         sublime_plugin.WindowCommand.__init__(self, *args, **kwargs)
 
     def get_manage_py(self):
-        return self.settings.get('django_project_root') or self.find_manage_py()
+        return self.find_manage_py()
 
     def get_executable(self):
         self.project_true = self.settings.get('project_override')
@@ -75,7 +75,9 @@ class DjangoCommand(sublime_plugin.WindowCommand):
             return version
 
     def find_manage_py(self):
-        django_project_root = sublime.active_window().active_view().settings().get('django_project_root')
+        django_project_root = \
+            sublime.active_window().active_view().settings().get('django_project_root') \
+            or self.settings.get('django_project_root')
         for path in [django_project_root] if django_project_root else sublime.active_window().folders():
             for root, dirs, files in os.walk(path):
                 if 'manage.py' in files:

--- a/django-commands.py
+++ b/django-commands.py
@@ -75,7 +75,8 @@ class DjangoCommand(sublime_plugin.WindowCommand):
             return version
 
     def find_manage_py(self):
-        for path in sublime.active_window().folders():
+        django_project_root = sublime.active_window().active_view().settings().get('django_project_root')
+        for path in [django_project_root] if django_project_root else sublime.active_window().folders():
             for root, dirs, files in os.walk(path):
                 if 'manage.py' in files:
                     return os.path.join(root, 'manage.py')


### PR DESCRIPTION
Adds an option to specify per-project `django_project_root` from `.sublime-project` files.

Also fixes a bug where `get_manage_py` returning only a path (without `/manage.py`) when `django_project_root` is set in `DjangoCommands.sublime-settings` file.