### PR TITLE
Skip TERMINAL definition for Windows; Issue #34 related

### DIFF
--- a/django-commands.py
+++ b/django-commands.py
@@ -120,13 +120,14 @@ class DjangoCommand(sublime_plugin.WindowCommand):
 
     def define_terminal(self):
         global TERMINAL
-        settings_names = {"Linux": "linux_terminal", "Darwin": "osx_terminal"}
-        fallbacks = {"Linux": "xterm", "Darwin": "Terminal"}
-        TERMINAL = self.settings.get(settings_names.get(PLATFORM), fallbacks.get(PLATFORM))
-        if not which(TERMINAL, mode=os.F_OK | os.X_OK):
-            self.error_msg = 'terminal emulator not found: {}\nUsing fallback instead'.format(TERMINAL)
-            self.display_error_message()
-            TERMINAL = fallbacks.get(PLATFORM)
+        if PLATFORM != 'Windows':
+            settings_names = {"Linux": "linux_terminal", "Darwin": "osx_terminal"}
+            fallbacks = {"Linux": "xterm", "Darwin": "Terminal"}
+            TERMINAL = self.settings.get(settings_names.get(PLATFORM), fallbacks.get(PLATFORM))
+            if not which(TERMINAL, mode=os.F_OK | os.X_OK):
+                self.error_msg = 'terminal emulator not found: {}\nUsing fallback instead'.format(TERMINAL)
+                self.display_error_message()
+                TERMINAL = fallbacks.get(PLATFORM)
 
     def display_error_message(self):
         sublime.error_message(self.error_msg)


### PR DESCRIPTION
Skipping this section for Windows resolves "TypeError: String required" error being thrown as per Issue #34. 
TERMINAL is only used if PLATFORM isn't Windows, so definition is not necessary.