### PR TITLE
Ensure no blank arguments in command list for Windows; Issue #41 related

### DIFF
--- a/django-commands.py
+++ b/django-commands.py
@@ -162,7 +162,7 @@ class CommandThread(threading.Thread):
 
         if PLATFORM == 'Windows':
             command = ['cmd.exe', '/k']
-            command.extend(self.command)
+            command.extend(list(filter(None, self.command)))
             command.extend(['&&', 'timeout', '/T', '10', '&&', 'exit'])
 
         elif(self.notsplit):


### PR DESCRIPTION
This change ensures that no blank arguments reach the subprocess.Popen command in Windows which fixes Issue #41 whereby any commands with a blank list element will fail.